### PR TITLE
Fix-rnd-loss-mask-shape

### DIFF
--- a/mighty/mighty_meta/rnd.py
+++ b/mighty/mighty_meta/rnd.py
@@ -169,7 +169,7 @@ class RND(MightyMetaComponent):
                 obs = batch.observations
             prediction, target = self.rnd_net(obs)
             loss = nn.MSELoss(reduction="none")(prediction, target.detach()).mean(-1)
-            mask = torch.rand(len(loss))
+            mask = torch.rand(loss.shape)
             mask = mask < self.update_proportion
             loss = (loss * mask).sum() / torch.max(mask.sum(), torch.tensor([1]))
             self.rnd_optimizer.zero_grad()


### PR DESCRIPTION
In RND, the loss mask currently uses the loss length to generate the masking. This can cause issues in several trivial cases, though, so this PR switches to shape instead.