### PR TITLE
Add missing dois

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -43,7 +43,8 @@
   author={Cho, J. and Jayawardana, V. and Li, S. and Wu, C.},
   booktitle={Proceedings of the 38th International Conference on Advances in Neural Information Processing Systems (NeurIPS'24)},
   publisher={Curran Associates},
-  year={2024}
+  year={2024},
+  doi={10.52202/079017-2801}
 }
 
 @inproceedings{dabney-iclr21,
@@ -59,7 +60,8 @@
   title={Resource usage evaluation of discrete model-free deep reinforcement learning algorithms},
   author={Dizon-Paradis, O. and Wormald, S. and Capecci, D. and Bhandarkar, A. and Woodard, D.},
   journal={Reinforcement Learning Journal},
-  year={2024}
+  year={2024},
+  doi={10.36227/techrxiv.23739099.v2}
 }
 
 @inproceedings{eimer-icml21a,
@@ -139,7 +141,8 @@
   title={Fast online adaptation in robotics through meta-learning embeddings of simulated priors},
   author={Kaushik, R. and Anne, T. and Mouret, Je.},
   booktitle={IEEE/RSJ International Conference on Intelligent Robots and Systems, (IROS'20)},
-  year={2020}
+  year={2020},
+  doi={10.1109/iros45743.2020.9341462}
 }
 
 @article{kirk-jair23a,
@@ -148,14 +151,16 @@
   journal={Journal of Artificial Intelligence Research (JAIR)},
   volume={76},
   pages={201--264},
-  year={2023}
+  year={2023},
+  doi={10.1613/jair.1.14174}
 }
 
 @article{evosax2022github,
   title={evosax: Jax-based evolution strategies},
   author={Lange, Robert Tjarko},
   journal={arXiv preprint arXiv:2212.04180},
-  year={2022}
+  year={2022},
+  doi={10.1145/3583133.3590733}
 }
 
 @article{lee-sciro20a,
@@ -216,7 +221,8 @@
   author={Mohan, A. and Zhang, A. and Lindauer, M.},
   journal={Journal of Artificial Intelligence Research},
   volume={79},
-  year={2024}
+  year={2024},
+  doi={10.1613/jair.1.15703}
 }
 
 @article{parkerholder-jair22a,
@@ -225,7 +231,8 @@
   journal={Journal of Artificial Intelligence Research (JAIR)},
   volume={74},
   pages={517--568},
-  year={2022}
+  year={2022},
+  doi={10.1613/jair.1.13596}
 }
 
 @article{raffin-jmlr21a,
@@ -284,7 +291,8 @@
   booktitle={2017 IEEE/RSJ International Conference on Intelligent Robots and Systems, IROS},
   pages={23--30},
   publisher={IEEE},
-  year={2017}
+  year={2017},
+  doi={10.1109/iros.2017.8202133}
 }
 
 @misc{toledo-misc24a,


### PR DESCRIPTION
These DOIs are just for papers marked missing. For many of the skipped ones, I don't think we have any (e.g. ICML).