### PR TITLE
Fix: Add configuration files to package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ examples = []
 [tool.setuptools.packages.find]
 include = ["mighty*", "examples"]
 
+[tool.setuptools.package-data]
+"*" = ["*.yaml"]
+
 [tool.ruff]
 extend-exclude = []
 


### PR DESCRIPTION
The distributed package was missing the files in `mighty/configs` because setuptools disregards them by default. I assume these are supposed to be distributed since they are inside the package folder.

This PR adds them explicitly.