### PR TITLE
fix(exploration): typo self.ago -> self.algo in sample_func_logits

### DIFF
--- a/mighty/mighty_exploration/mighty_exploration_policy.py
+++ b/mighty/mighty_exploration/mighty_exploration_policy.py
@@ -111,7 +111,7 @@ class MightyExplorationPolicy:
         elif isinstance(out, tuple) and len(out) == 4:
             action = out[0]  # [batch, action_dim]
             log_prob = sample_nondeterministic_logprobs(
-                z=out[1], mean=out[2], log_std=out[3], sac=self.ago == "sac"
+                z=out[1], mean=out[2], log_std=out[3], sac=self.algo == "sac"
             )
             return action.detach().cpu().numpy(), log_prob
 


### PR DESCRIPTION
## Summary

In `MightyExplorationPolicy.sample_func_logits`, the `sac` flag passed to `sample_nondeterministic_logprobs` used `self.ago` instead of `self.algo`.

```python
# Before (broken)
log_prob = sample_nondeterministic_logprobs(
    z=out[1], mean=out[2], log_std=out[3], sac=self.ago == "sac"
)

# After (fixed)
log_prob = sample_nondeterministic_logprobs(
    z=out[1], mean=out[2], log_std=out[3], sac=self.algo == "sac"
)
```

## Impact

Because `self.ago` does not exist, the expression always evaluated to `False`, so the tanh-squash log-probability correction was **never applied** for SAC in this code path — even though SAC requires it. This caused old log-probs stored in the rollout buffer to be plain Gaussian log-probs without the tanh correction, introducing a systematic bias in the PPO importance-sampling ratio.