### PR TITLE
Fix PPO importance-sampling ratio bias with squashed-Gaussian policies

### DIFF
--- a/mighty/mighty_exploration/mighty_exploration_policy.py
+++ b/mighty/mighty_exploration/mighty_exploration_policy.py
@@ -9,27 +9,30 @@ from torch.distributions import Categorical, Normal
 
 
 def sample_nondeterministic_logprobs(
-    z: torch.Tensor, mean: torch.Tensor, log_std: torch.Tensor, sac: bool = False
+    z: torch.Tensor, mean: torch.Tensor, log_std: torch.Tensor
 ) -> torch.Tensor:
     """
-    Compute log-prob of a Gaussian sample z ~ N(mean, exp(log_std)),
-    and if sac=True apply the tanh-squash correction to get log π(a).
+    Compute log π(a) for a squashed-Gaussian policy.
+
+    Given a pre-tanh sample z ~ N(mean, exp(log_std)) and squashed action
+    a = tanh(z), returns the log-probability under the policy:
+
+        log π(a) = log N(z | mean, std) − ∑ log(1 − tanh(z)²)
+
+    Applying this correction consistently for both old and new log-probs
+    ensures it cancels in the PPO importance-sampling ratio.
     """
     std = torch.exp(log_std)  # [batch, action_dim]
     dist = Normal(mean, std)
     # base Gaussian log‐prob of z
     log_pz = dist.log_prob(z).sum(dim=-1, keepdim=True)  # [batch, 1]
 
-    if sac:
-        # subtract the ∑_i log(d tanh/dz_i) = ∑ log(1 - tanh(z)^2)
-        eps = 1e-4
-        log_correction = torch.log(1.0 - torch.tanh(z).pow(2) + eps).sum(
-            dim=-1, keepdim=True
-        )  # [batch, 1]
-        return log_pz - log_correction
-    else:
-        # PPO-style or other: no squash correction
-        return log_pz
+    # subtract the ∑_i log(d tanh/dz_i) = ∑ log(1 - tanh(z)^2)
+    eps = 1e-6
+    log_correction = torch.log(1.0 - torch.tanh(z).pow(2) + eps).sum(
+        dim=-1, keepdim=True
+    )  # [batch, 1]
+    return log_pz - log_correction
 
 
 class MightyExplorationPolicy:
@@ -110,8 +113,9 @@ class MightyExplorationPolicy:
         # ─── Continuous squashed‐Gaussian (4‐tuple) ──────────────────────────
         elif isinstance(out, tuple) and len(out) == 4:
             action = out[0]  # [batch, action_dim]
+            # 4-tuple signals squashed Gaussian — always apply tanh correction
             log_prob = sample_nondeterministic_logprobs(
-                z=out[1], mean=out[2], log_std=out[3], sac=self.ago == "sac"
+                z=out[1], mean=out[2], log_std=out[3]
             )
             return action.detach().cpu().numpy(), log_prob
 

--- a/mighty/mighty_exploration/mighty_exploration_policy.py
+++ b/mighty/mighty_exploration/mighty_exploration_policy.py
@@ -9,30 +9,36 @@ from torch.distributions import Categorical, Normal
 
 
 def sample_nondeterministic_logprobs(
-    z: torch.Tensor, mean: torch.Tensor, log_std: torch.Tensor
+    z: torch.Tensor,
+    mean: torch.Tensor,
+    log_std: torch.Tensor,
+    tanh_squash: bool = False,
 ) -> torch.Tensor:
     """
-    Compute log π(a) for a squashed-Gaussian policy.
+    Compute log-prob of a Gaussian sample z ~ N(mean, exp(log_std)).
 
-    Given a pre-tanh sample z ~ N(mean, exp(log_std)) and squashed action
-    a = tanh(z), returns the log-probability under the policy:
+    If tanh_squash=True, applies the change-of-variables correction for
+    the squashed action a = tanh(z):
 
         log π(a) = log N(z | mean, std) − ∑ log(1 − tanh(z)²)
 
-    Applying this correction consistently for both old and new log-probs
-    ensures it cancels in the PPO importance-sampling ratio.
+    Both old and new log-probs must use the same value of tanh_squash so
+    the correction cancels correctly in the PPO importance-sampling ratio.
     """
     std = torch.exp(log_std)  # [batch, action_dim]
     dist = Normal(mean, std)
     # base Gaussian log‐prob of z
     log_pz = dist.log_prob(z).sum(dim=-1, keepdim=True)  # [batch, 1]
 
-    # subtract the ∑_i log(d tanh/dz_i) = ∑ log(1 - tanh(z)^2)
-    eps = 1e-6
-    log_correction = torch.log(1.0 - torch.tanh(z).pow(2) + eps).sum(
-        dim=-1, keepdim=True
-    )  # [batch, 1]
-    return log_pz - log_correction
+    if tanh_squash:
+        # subtract the ∑_i log(d tanh/dz_i) = ∑ log(1 - tanh(z)^2)
+        eps = 1e-6
+        log_correction = torch.log(1.0 - torch.tanh(z).pow(2) + eps).sum(
+            dim=-1, keepdim=True
+        )  # [batch, 1]
+        return log_pz - log_correction
+
+    return log_pz
 
 
 class MightyExplorationPolicy:
@@ -113,9 +119,9 @@ class MightyExplorationPolicy:
         # ─── Continuous squashed‐Gaussian (4‐tuple) ──────────────────────────
         elif isinstance(out, tuple) and len(out) == 4:
             action = out[0]  # [batch, action_dim]
-            # 4-tuple signals squashed Gaussian — always apply tanh correction
             log_prob = sample_nondeterministic_logprobs(
-                z=out[1], mean=out[2], log_std=out[3]
+                z=out[1], mean=out[2], log_std=out[3],
+                tanh_squash=getattr(self.model, "tanh_squash", False),
             )
             return action.detach().cpu().numpy(), log_prob
 

--- a/mighty/mighty_exploration/stochastic_policy.py
+++ b/mighty/mighty_exploration/stochastic_policy.py
@@ -87,9 +87,10 @@ class StochasticPolicy(MightyExplorationPolicy):
             # 4-tuple case (Tanh squashing): (action, z, mean, log_std)
             elif isinstance(model_output, tuple) and len(model_output) == 4:
                 action, z, mean, log_std = model_output
-
-                # Always apply tanh correction — 4-tuple signals squashed Gaussian
-                log_prob = sample_nondeterministic_logprobs(z=z, mean=mean, log_std=log_std)
+                log_prob = sample_nondeterministic_logprobs(
+                    z=z, mean=mean, log_std=log_std,
+                    tanh_squash=getattr(self.model, "tanh_squash", False),
+                )
 
                 if return_logp:
                     return action.detach().cpu().numpy(), log_prob
@@ -112,7 +113,10 @@ class StochasticPolicy(MightyExplorationPolicy):
                 elif len(model_output) == 4:
                     # Tanh squashing mode: (action, z, mean, log_std)
                     action, z, mean, log_std = model_output
-                    log_prob = sample_nondeterministic_logprobs(z=z, mean=mean, log_std=log_std)
+                    log_prob = sample_nondeterministic_logprobs(
+                        z=z, mean=mean, log_std=log_std,
+                        tanh_squash=getattr(self.model, "tanh_squash", False),
+                    )
                 else:
                     raise ValueError(
                         f"Unexpected model output length: {len(model_output)}"
@@ -129,7 +133,10 @@ class StochasticPolicy(MightyExplorationPolicy):
                 if self.model.output_style == "squashed_gaussian":
                     # Should be 4-tuple: (action, z, mean, log_std)
                     action, z, mean, log_std = model_output
-                    log_prob = sample_nondeterministic_logprobs(z=z, mean=mean, log_std=log_std)
+                    log_prob = sample_nondeterministic_logprobs(
+                        z=z, mean=mean, log_std=log_std,
+                        tanh_squash=getattr(self.model, "tanh_squash", False),
+                    )
 
                     if return_logp:
                         return action.detach().cpu().numpy(), log_prob
@@ -144,7 +151,10 @@ class StochasticPolicy(MightyExplorationPolicy):
                     z = dist.rsample()
                     action = torch.tanh(z)
                     log_std = torch.log(std)
-                    log_prob = sample_nondeterministic_logprobs(z=z, mean=mean, log_std=log_std)
+                    log_prob = sample_nondeterministic_logprobs(
+                        z=z, mean=mean, log_std=log_std,
+                        tanh_squash=getattr(self.model, "tanh_squash", False),
+                    )
 
                     entropy = dist.entropy().sum(dim=-1, keepdim=True)
                     weighted_log_prob = log_prob * entropy

--- a/mighty/mighty_exploration/stochastic_policy.py
+++ b/mighty/mighty_exploration/stochastic_policy.py
@@ -88,15 +88,8 @@ class StochasticPolicy(MightyExplorationPolicy):
             elif isinstance(model_output, tuple) and len(model_output) == 4:
                 action, z, mean, log_std = model_output
 
-                if not self.algo == "sac":
-                    log_prob = sample_nondeterministic_logprobs(
-                        z=z,
-                        mean=mean,
-                        log_std=log_std,
-                        sac=False,
-                    )
-                else:
-                    log_prob = self.model.policy_log_prob(z, mean, log_std)
+                # Always apply tanh correction — 4-tuple signals squashed Gaussian
+                log_prob = sample_nondeterministic_logprobs(z=z, mean=mean, log_std=log_std)
 
                 if return_logp:
                     return action.detach().cpu().numpy(), log_prob
@@ -119,15 +112,7 @@ class StochasticPolicy(MightyExplorationPolicy):
                 elif len(model_output) == 4:
                     # Tanh squashing mode: (action, z, mean, log_std)
                     action, z, mean, log_std = model_output
-                    if not self.algo == "sac":
-                        log_prob = sample_nondeterministic_logprobs(
-                            z=z,
-                            mean=mean,
-                            log_std=log_std,
-                            sac=False,
-                        )
-                    else:
-                        log_prob = self.model.policy_log_prob(z, mean, log_std)
+                    log_prob = sample_nondeterministic_logprobs(z=z, mean=mean, log_std=log_std)
                 else:
                     raise ValueError(
                         f"Unexpected model output length: {len(model_output)}"
@@ -144,15 +129,7 @@ class StochasticPolicy(MightyExplorationPolicy):
                 if self.model.output_style == "squashed_gaussian":
                     # Should be 4-tuple: (action, z, mean, log_std)
                     action, z, mean, log_std = model_output
-                    if not self.algo == "sac":
-                        log_prob = sample_nondeterministic_logprobs(
-                            z=z,
-                            mean=mean,
-                            log_std=log_std,
-                            sac=False,
-                        )
-                    else:
-                        log_prob = self.model.policy_log_prob(z, mean, log_std)
+                    log_prob = sample_nondeterministic_logprobs(z=z, mean=mean, log_std=log_std)
 
                     if return_logp:
                         return action.detach().cpu().numpy(), log_prob
@@ -166,16 +143,8 @@ class StochasticPolicy(MightyExplorationPolicy):
                     dist = Normal(mean, std)
                     z = dist.rsample()
                     action = torch.tanh(z)
-
-                    if not self.algo == "sac":
-                        log_prob = sample_nondeterministic_logprobs(
-                            z=z,
-                            mean=mean,
-                            log_std=log_std,
-                            sac=False,
-                        )
-                    else:
-                        log_prob = self.model.policy_log_prob(z, mean, log_std)
+                    log_std = torch.log(std)
+                    log_prob = sample_nondeterministic_logprobs(z=z, mean=mean, log_std=log_std)
 
                     entropy = dist.entropy().sum(dim=-1, keepdim=True)
                     weighted_log_prob = log_prob * entropy

--- a/mighty/mighty_models/sac.py
+++ b/mighty/mighty_models/sac.py
@@ -12,6 +12,7 @@ class SACModel(nn.Module):
     output_style = (
         "squashed_gaussian"  # For continuous actions, we use squashed Gaussian output
     )
+    tanh_squash: bool = True  # SAC always uses tanh squashing
 
     def __init__(
         self,


### PR DESCRIPTION
## Fix PPO importance-sampling ratio bias with squashed-Gaussian policies

### Problem
When PPO uses a squashed-Gaussian policy (4-tuple output: `action, z, mean, log_std`), the importance-sampling ratio becomes biased:

- During rollout, `old_log_probs` stored in the buffer are computed without the tanh change-of-variables correction
- During the PPO update, `new_log_probs` include the correction
- The correction does not cancel in the ratio:
  ```
  ratio = exp(log_π_new(a) - log_π_old(a))
        = exp([log N(z|new) - log_correction] - log N(z|old))
        = [N(z|new)/N(z|old)] × 1/(1 - tanh(z)²)
  ```
- The spurious `1/(1 - tanh(z)²)` factor explodes as actions approach ±1, causing gradient instability

### Solution
**Two commits:**

1. **Always apply tanh correction at rollout time** (97e8391)  
   - Remove the `sac=` gate from `sample_nondeterministic_logprobs`
   - Apply the correction whenever the model outputs a 4-tuple (which is the canonical signal that squashing is active)
   - This ensures `old_log_probs` stored in the buffer are already corrected, so the correction cancels correctly in the PPO update

2. **Check tanh_squash attribute explicitly** (5e59c37)  
   - Add `tanh_squash=True` to `SACModel` as a class attribute (matching `PPOModel`)
   - Pass `tanh_squash=getattr(self.model, "tanh_squash", False)` to `sample_nondeterministic_logprobs` at each call site
   - Makes the intent explicit and allows future models to opt in/out cleanly