### PR TITLE
Release v1.0.1: JOSS review fixes (code only, paper stays on joss_paper)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in Mighty a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at a.mohan@ai.uni-hannover.de. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to Mighty
+
+Thank you for your interest in contributing to Mighty! This document covers how to set up your environment, run tests, submit changes, and get support.
+
+## Setting Up a Development Environment
+
+We recommend [uv](https://github.com/astral-sh/uv) for environment management.
+
+```bash
+uv venv --python=3.11
+source .venv/bin/activate
+make install-dev   # installs Mighty in editable mode with all dev dependencies
+```
+
+Optional environment backends:
+
+```bash
+uv pip install -e ".[carl]"       # CARL environments
+uv pip install -e ".[dacbench]"   # DACBench environments
+uv pip install -e ".[pufferlib]"  # Pufferlib environments
+```
+
+## Running Tests
+
+```bash
+make test                                      # full test suite with coverage
+uv run pytest test/test_cli.py -v              # single file
+uv run pytest test/ -k "test_name" -v         # single test by name
+```
+
+## Linting and Formatting
+
+```bash
+make check    # check formatting (ruff format --check + ruff check)
+make format   # auto-fix formatting (isort + ruff format + ruff check --fix)
+make typing   # run mypy type checks
+```
+
+Please ensure `make check` passes before submitting a pull request.
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a branch from `main`.
+2. Make your changes, including tests for any new functionality.
+3. Ensure `make test` and `make check` both pass locally.
+4. Open a pull request and fill in the PR template, including references to any related issues.
+
+We review pull requests on a best-effort basis. We appreciate your patience — if a review is slow it is usually because the reviewers are busy, not because the contribution is unwelcome.
+
+## Reporting Issues
+
+Please open a [GitHub issue](https://github.com/automl/Mighty/issues) with:
+- A minimal reproducible example
+- Your Python and Mighty version (`python --version`, `pip show mighty-rl`)
+- The full error traceback
+
+Check existing issues before opening a new one.
+
+## Getting Support
+
+- **GitHub Issues** — for bugs and feature requests
+- **GitHub Discussions** — for questions and general usage help
+- **Email** — for anything else: a.mohan@ai.uni-hannover.de
+
+## Code of Conduct
+
+All contributors are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ python mighty/run_mighty.py 'algorithm=ppo' 'environment=gymnasium/pendulum'
 
 ### Train your Agent on a CARL Environment
 Mighty is designed with contextual RL in mind and therefore fully compatible with CARL.
-Before you start training, however, please follow the installation instructions in the [CARL repo](https://github.com/automl/CARL).
+Before you start training, install the CARL extra so that `carl` is available in your
+Mighty environment (see [CARL](https://github.com/automl/CARL) for more on the benchmark itself):
+```bash
+pip install -e ".[carl]"
+```
+(`make install-dev` installs this along with all other optional dependencies.)
 
 Then use the same command as before, but provide the CARL environment, in this example CARLCartPoleEnv,
 and information about the context distribution as keywords:
@@ -93,8 +98,13 @@ For more complex configurations like this, we recommend making an environment co
 
 ### Learning a Configuration Policy via DAC
 
-In order to use Mighty with DACBench, you need to install DACBench first.
-We recommend following the instructions in the [DACBench repo](https://github.com/automl/DACBench).
+In order to use Mighty with DACBench, install the DACBench extra so that `dacbench`
+is available in your Mighty environment (see [DACBench](https://github.com/automl/DACBench)
+for more on the benchmark itself):
+```bash
+pip install -e ".[dacbench]"
+```
+(`make install-dev` installs this along with all other optional dependencies.)
 
 Afterwards, configure the benchmark you want to run. Since most DACBench benchmarks have Dict action and observation spaces, some fairly complex,  you might need to wrap DACBenchmarks in order to translate the observations and actions to an easy-to-handle format. We have a version of the FunctionApproximationBenchmark configured for you so you can get started like this:
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,8 +71,7 @@ mindmap
 
 ### Where Is Mighty Going?
 
-Currently Mighty is in early development and includes only standard RL algorithms compatible with cRL benchmarks and
-evaluation mechanisms. In the future, we hope to extend mighty with Meta-Learning methods as well as AutoRL, so stay tuned.
+Mighty currently supports DQN, PPO, and SAC with a range of contextual RL benchmarks and evaluation mechanisms. Future work will deepen support for Meta-RL and AutoRL — stay tuned.
 
 ### Contact & Citation
 Mighty is developed at [LUHAI Hannover]() by members of [AutoRL.org](). Your first contact is lead maintainer [Aditya Mohan](). If you found issues or want to contribute new features, it's best to visit our [GitHub page](https://github.com/automl/Mighty) page and start a discussion.
@@ -81,7 +80,7 @@ If you use Mighty for your research, please cite us:
 
 ```bibtex
 @misc{mohaneimer24,
-  author    = {A. Mohan and T. Eimer and C. Benjamins and F. Hutter and M. Lindauer and A. Biedenkapp},
+  author    = {A. Mohan and T. Eimer and C. Benjamins and M. Lindauer and A. Biedenkapp},
   title     = {Mighty},
   year      = {2024},
   url = {https://github.com/automl/mighty}

--- a/mighty/configs/environment/gymnasium/halfcheetah.yaml
+++ b/mighty/configs/environment/gymnasium/halfcheetah.yaml
@@ -1,0 +1,7 @@
+# @package _global_
+
+num_steps: 1_000_000
+env: HalfCheetah-v4
+env_kwargs: {}
+env_wrappers: []
+num_envs: 1

--- a/mighty/configs/environment/gymnasium/walker2d.yaml
+++ b/mighty/configs/environment/gymnasium/walker2d.yaml
@@ -1,0 +1,7 @@
+# @package _global_
+
+num_steps: 1_000_000
+env: Walker2d-v4
+env_kwargs: {}
+env_wrappers: []
+num_envs: 1

--- a/mighty/mighty_agents/base_agent.py
+++ b/mighty/mighty_agents/base_agent.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import os
 import random
 from abc import ABC
 from pathlib import Path
-from warnings import warn
 from typing import TYPE_CHECKING, Dict
 
 import numpy as np
@@ -46,6 +46,25 @@ except ImportError:
     print(
         "Using default wandb logging. If you prefer trackio, please install it with `pip install trackio`."
     )
+
+
+def _json_default(obj):
+    """Fallback encoder for ``json.dump`` of instance/context sets.
+
+    CARL contexts are plain dicts of numbers and serialize directly, but
+    DACbench instance sets contain dataclass objects (e.g.
+    ``FunctionApproximationInstance``) that hold non-serializable members.
+    Convert dataclasses to dicts and fall back to ``str`` for anything else
+    so the ``instance_set.json`` artifact can always be written (see #123).
+    """
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        try:
+            return dataclasses.asdict(obj)
+        except Exception:
+            return str(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    return str(obj)
 
 
 def seed_env_spaces(env: gym.VectorEnv, seed: int) -> None:
@@ -297,15 +316,11 @@ class MightyAgent(ABC):
         ):
             self.result_buffer["instances"] = []
 
-            def default_serialization(obj):
-                warn(f"'{type(obj)}' not serializable", UserWarning)
-                return str(obj)
-
             with open(Path(self.output_dir) / "instance_set.json", "w+") as f:
-                json.dump(self.env.instance_set, f, default=default_serialization)
+                json.dump(self.env.instance_set, f, default=_json_default)
 
             with open(Path(self.output_dir) / "test_set.json", "w+") as f:
-                json.dump(self.eval_env.instance_set, f, default=default_serialization)
+                json.dump(self.eval_env.instance_set, f, default=_json_default)
 
         self.eval_buffer = {
             "eval_after_n_steps": [],

--- a/mighty/mighty_agents/base_agent.py
+++ b/mighty/mighty_agents/base_agent.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 import gymnasium as gym
 from gymnasium.wrappers import RescaleAction
-from gymnasium.wrappers.normalize import NormalizeObservation, NormalizeReward
+from gymnasium.wrappers import NormalizeObservation, NormalizeReward
 
 try:
     import logging

--- a/mighty/mighty_agents/base_agent.py
+++ b/mighty/mighty_agents/base_agent.py
@@ -24,7 +24,7 @@ from uniplot import plot_to_string
 
 from mighty.mighty_exploration import MightyExplorationPolicy
 from mighty.mighty_replay import MightyReplay, MightyRolloutBuffer, PrioritizedReplay
-from mighty.mighty_utils.mighty_types import CARLENV, DACENV, MIGHTYENV, retrieve_class
+from mighty.mighty_utils.mighty_types import MIGHTYENV, retrieve_class
 
 if TYPE_CHECKING:
     from mighty.mighty_utils.mighty_types import TypeKwargs
@@ -310,10 +310,7 @@ class MightyAgent(ABC):
             "truncated": [],
             "mean_episode_reward": [],
         }
-        if hasattr(self.env, "unwrapped") and (
-            isinstance(self.env.unwrapped, DACENV)
-            or isinstance(self.env.unwrapped, CARLENV)
-        ):
+        if getattr(self.env, "instance_set", None) is not None:
             self.result_buffer["instances"] = []
 
             with open(Path(self.output_dir) / "instance_set.json", "w+") as f:
@@ -719,10 +716,7 @@ class MightyAgent(ABC):
 
                 t.update(infos)
 
-                if hasattr(self.env, "unwrapped") and (
-                    isinstance(self.env.unwrapped, DACENV)
-                    or isinstance(self.env.unwrapped, CARLENV)
-                ):
+                if getattr(self.env, "inst_ids", None) is not None:
                     t["instances"] = self.env.inst_ids
 
                 metrics["log_prob"] = log_prob.detach().cpu().numpy()
@@ -912,10 +906,7 @@ class MightyAgent(ABC):
                 last_info = info
             mask = np.where(dones, 1, mask)
 
-        if hasattr(self.eval_env, "unwrapped") and (
-            isinstance(self.eval_env.unwrapped, DACENV)
-            or isinstance(self.eval_env.unwrapped, CARLENV)
-        ):
+        if getattr(self.eval_env, "inst_ids", None) is not None:
             instances = eval_env.inst_ids  # type: ignore
         else:
             instances = "None"

--- a/mighty/mighty_utils/wrappers.py
+++ b/mighty/mighty_utils/wrappers.py
@@ -154,7 +154,9 @@ class CARLVectorEnvSimulator(gym.vector.VectorEnv):
             if "seed" in kwargs and not isinstance(kwargs["seed"], int):
                 kwargs["seed"] = int(kwargs["seed"][0])
             obs, info = self.env.reset(**kwargs)
-            return np.array([obs]), np.array([info])
+            # info stays a dict (gymnasium VectorEnv convention); only the
+            # numeric obs gets a batch dimension. See issue #122.
+            return np.array([obs]), info
 
     def step(self, actions):
         if self.num_envs > 1:
@@ -163,12 +165,14 @@ class CARLVectorEnvSimulator(gym.vector.VectorEnv):
             obs, reward, te, tr, info = self.env.step(actions[0])
             if te or tr:
                 obs, info = self.env.reset()
+            # info stays a dict (gymnasium VectorEnv convention); only the
+            # numeric outputs get a batch dimension. See issue #122.
             return (
                 np.array([obs]),
                 np.array([reward]),
                 np.array([te]),
                 np.array([tr]),
-                np.array([info]),
+                info,
             )
 
     @property

--- a/mighty/mighty_utils/wrappers.py
+++ b/mighty/mighty_utils/wrappers.py
@@ -236,8 +236,13 @@ class ContextualVecEnv(gym.vector.SyncVectorEnv):
                 self.envs[i].set_instance_set(ps)
 
     def close(self):
+        # Guard against double-close: gym's VectorEnv.__del__ also calls
+        # close(), and some envs (e.g. DACbench) are not idempotent on close.
+        if getattr(self, "closed", False):
+            return
         for env in self.envs:
             env.close()
+        self.closed = True
 
 
 class ProcgenVecEnv(gym.vector.SyncVectorEnv):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Mighty-RL"
-version = "1.0.0"
+version = "1.0.1"
 description = "A modular, meta-learning-ready RL library."
 authors = [{ name = "AutoRL@LUHAI", email = "a.mohan@ai.uni-hannover.de" }]
 readme = "README.md"

--- a/test/agents/test_base_agent.py
+++ b/test/agents/test_base_agent.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
+import json
 from pathlib import Path
 
 import gymnasium as gym
@@ -7,6 +9,26 @@ import pytest
 
 from mighty.mighty_agents.dqn import MightyAgent, MightyDQNAgent
 from mighty.mighty_utils.test_helpers import DummyEnv, clean
+from mighty.mighty_utils.wrappers import ContextualVecEnv
+
+
+@dataclasses.dataclass
+class _NonSerializableInstance:
+    """Mimics DACbench instance dataclasses that hold non-JSON objects."""
+
+    fn: object
+    coeffs: list
+
+
+class _DACInstanceEnv(DummyEnv):
+    """DummyEnv whose instance_set holds a non-serializable dataclass,
+    mirroring DACbench's FunctionApproximationInstance (see issue #123)."""
+
+    def __init__(self):
+        super().__init__()
+        self.instance_set = {
+            0: _NonSerializableInstance(fn=lambda x: x, coeffs=[1.0, 2.0])
+        }
 
 
 class TestMightyAgent:
@@ -44,4 +66,21 @@ class TestMightyAgent:
         }
         agent.apply_config(config)
         assert agent.learning_rate == -1
+        clean(output_dir)
+
+    def test_init_dumps_non_serializable_instance_set(self):
+        """Regression for #123: DACbench instance sets contain dataclass
+        objects that are not JSON-serializable. Agent init must still write
+        an instance_set.json artifact rather than crashing."""
+        env = ContextualVecEnv([_DACInstanceEnv for _ in range(2)])
+        eval_env = ContextualVecEnv([_DACInstanceEnv for _ in range(2)])
+        output_dir = Path("test_base_agent")
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        agent = MightyDQNAgent(output_dir, env, eval_env=eval_env)
+
+        instance_file = Path(agent.output_dir) / "instance_set.json"
+        assert instance_file.exists()
+        with open(instance_file) as f:
+            json.load(f)  # must be valid JSON
         clean(output_dir)

--- a/test/test_wrappers.py
+++ b/test/test_wrappers.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import gymnasium as gym
+
+from mighty.mighty_utils.wrappers import ContextualVecEnv
+
+
+class _DacLikeCloseEnv(gym.Env):
+    """Env whose close() is not idempotent, like DACbench envs which do
+    ``del self.instance_set`` on close (see issue #123)."""
+
+    def __init__(self):
+        self.observation_space = gym.spaces.Box(low=-1, high=1, shape=(2,))
+        self.action_space = gym.spaces.Discrete(2)
+        self.inst_id = 0
+        self.instance_set = {0: 1}
+
+    @property
+    def instance_id_list(self):
+        return [0]
+
+    def reset(self, *args, **kwargs):
+        return self.observation_space.sample(), {}
+
+    def step(self, action):
+        return self.observation_space.sample(), 0.0, False, False, {}
+
+    def close(self):
+        del self.instance_set  # raises AttributeError if called twice
+
+
+class TestContextualVecEnv:
+    def test_close_is_idempotent(self):
+        """Regression for #123: closing the vec env more than once (e.g. via
+        both the agent's __del__ and gym's VectorEnv.__del__) must not crash
+        on envs whose close() is not idempotent."""
+        env = ContextualVecEnv([_DacLikeCloseEnv for _ in range(2)])
+        env.close()
+        env.close()  # second close must be a no-op
+        assert env.closed

--- a/test/test_wrappers.py
+++ b/test/test_wrappers.py
@@ -1,8 +1,28 @@
 from __future__ import annotations
 
 import gymnasium as gym
+import numpy as np
 
-from mighty.mighty_utils.wrappers import ContextualVecEnv
+from mighty.mighty_utils.wrappers import CARLVectorEnvSimulator, ContextualVecEnv
+
+
+class _StubCarlEnv:
+    """Minimal single env (no num_envs) for CARLVectorEnvSimulator, returning
+    a dict info like CARL does (e.g. {'context_id': 0}); see issue #122."""
+
+    def __init__(self):
+        self.action_space = gym.spaces.Discrete(2)
+        self.observation_space = gym.spaces.Box(low=-1, high=1, shape=(2,))
+        self.contexts = {0: {}}
+
+    def reset(self, **kwargs):
+        return np.zeros(2), {"context_id": 0}
+
+    def step(self, action):
+        return np.zeros(2), 1.0, False, False, {"context_id": 0}
+
+    def close(self):
+        pass
 
 
 class _DacLikeCloseEnv(gym.Env):
@@ -38,3 +58,23 @@ class TestContextualVecEnv:
         env.close()
         env.close()  # second close must be a no-op
         assert env.closed
+
+
+class TestCARLVectorEnvSimulator:
+    def test_single_env_step_info_is_dict(self):
+        """Regression for #122: the single-env path must return infos as a
+        dict so the training loop's t.update(infos) works, not a numpy
+        object array of dicts."""
+        env = CARLVectorEnvSimulator(_StubCarlEnv())
+        _, _, _, _, infos = env.step(np.array([0]))
+        assert isinstance(infos, dict)
+        merged = {"reward": 1.0}
+        merged.update(infos)  # must not raise
+
+    def test_single_env_reset_info_is_dict(self):
+        """Regression for #122: reset info must be a dict so log_infos'
+        info.keys() works."""
+        env = CARLVectorEnvSimulator(_StubCarlEnv())
+        _, info = env.reset()
+        assert isinstance(info, dict)
+        assert "context_id" in info


### PR DESCRIPTION
## Summary

Prepares the **v1.0.1** maintenance release from the JOSS review (openjournals/joss-reviews#10439). Brings the review's software/docs fixes onto `main` — **the paper writeup intentionally stays on the `joss_paper` branch** (matching the AutoML house style: DACbench/CARL/SMAC3 keep the paper off `main`).

## Changes
- **#116** — add `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and MuJoCo env configs
- **#123** — make the DACbench README example runnable (dataclass-aware `instance_set.json` encoder)
- **#122** — make the CARL README example runnable (env-wrapping fix)
- **#103/#108** — import `NormalizeObservation`/`NormalizeReward` from the stable `gymnasium.wrappers` path (the `.normalize` submodule path breaks on gymnasium ≥1.0)
- **Robustness fix** — gate instance-set/`inst_ids` logging on the env attribute actually used (`getattr(env, "instance_set"/"inst_ids", None)`) instead of `isinstance(env.unwrapped, DACENV/CARLENV)`, which silently no-oped on a base install because those types fall back to `int` when the `dacbench`/`carl` extras are absent
- docs: replace early-development language and fix the citation author list
- bump version `1.0.0 → 1.0.1`

## Verification
Full suite in the CI-equivalent environment (Python 3.11, `gymnasium<1`, all extras):

```
238 passed, 2 skipped, 0 failed
```

`ruff check` and `ruff format --check` both clean.

## Notes
- Reconciled against `main`'s independent divergence (its gymnasium pin, LICENSE, and PPO/serialization fixes are all preserved — fixes were cherry-picked, not overwritten).
- Once merged, creating the `v1.0.1` GitHub Release auto-publishes to PyPI (resolves the stale-PyPI half of #120).
