### PR TITLE
fix: Issues with PPO / PPOUpdate

### DIFF
--- a/mighty/mighty_agents/ppo.py
+++ b/mighty/mighty_agents/ppo.py
@@ -286,13 +286,29 @@ class MightyPPOAgent(MightyAgent):
         if log_prob is not None and log_prob.shape[-1] == 1:
             log_prob = log_prob.squeeze(-1)  # (64, 1) → (64,)
 
+        # `dones` only carries terminations; time-limit truncations must also cut
+        # the GAE trajectory, and their reward is bootstrapped with V(final_obs)
+        # (next_s holds the real final observation on truncation).
+        episode_starts = dones
+        if metrics is not None and "transition" in metrics:
+            truncated = np.asarray(metrics["transition"]["truncated"])
+            episode_starts = np.logical_or(dones, truncated).astype(np.float32)
+            if truncated.any():
+                next_values = (
+                    self.value_function(torch.as_tensor(next_s, dtype=torch.float32))
+                    .detach()
+                    .numpy()
+                    .reshape((next_s.shape[0],))
+                )
+                reward = reward + self.gamma * next_values * truncated
+
         rollout_batch = RolloutBatch(
             observations=curr_s,
             actions=action,
             rewards=reward,
             advantages=np.zeros_like(reward),  # Placeholder, compute later
             returns=np.zeros_like(reward),  # Placeholder, compute later
-            episode_starts=dones,
+            episode_starts=episode_starts,
             log_probs=log_prob,
             values=values,
             latents=latents,

--- a/mighty/mighty_replay/mighty_rollout_buffer.py
+++ b/mighty/mighty_replay/mighty_rollout_buffer.py
@@ -260,8 +260,10 @@ class MightyRolloutBuffer(MightyBuffer):
                 next_non_term = 1.0 - dones_t  # [n_envs], 0 if done, 1 otherwise
                 next_val = lv  # bootstrap from V(sₜ₊₁)
             else:
-                # On intermediate steps, look at "episode_starts" for whether step+1 was a new episode
-                next_non_term = 1.0 - eps_slice[step + 1]  # [n_envs]
+                # episode_starts[t] holds the done flag of transition t itself,
+                # so the boundary after step t is 1 - episode_starts[step]
+                # (matches the last-row case, which uses the final step's dones).
+                next_non_term = 1.0 - eps_slice[step]  # [n_envs]
                 next_val = val_slice[step + 1]  # [n_envs]
 
             r_t = rew_slice[step]  # shape = [n_envs]

--- a/mighty/mighty_update/ppo_update.py
+++ b/mighty/mighty_update/ppo_update.py
@@ -83,8 +83,11 @@ class PPOUpdate:
 
         # ─────────────────── cache old values & log-probs ───────────────────
         with torch.no_grad():
+            # squeeze(-1): value head outputs (..., 1); returns/advantages are (..., ),
+            # so without it (returns - values) broadcasts to a (B, B) matrix.
             old_values = [
-                self.model.forward_value(mb.observations) for mb in batch.minibatches
+                self.model.forward_value(mb.observations).squeeze(-1)
+                for mb in batch.minibatches
             ]
             old_log_probs = [mb.log_probs.clone() for mb in batch.minibatches]
 
@@ -108,7 +111,7 @@ class PPOUpdate:
                 adv = ((mb.advantages - adv_mean) / adv_std).detach()
 
                 # ---- value loss ---------------------------------------------------
-                values = self.model.forward_value(mb.observations)
+                values = self.model.forward_value(mb.observations).squeeze(-1)
                 if self.use_value_clip:
                     clipped = old_values[i] + (values - old_values[i]).clamp(
                         -self.value_clip_eps, self.value_clip_eps


### PR DESCRIPTION
- Fixed issue, where critic_values were broadcast to ``(1, B, B)`` due to mb.returns with shape ``(1, B)``
- Fixed issue, where GAE applies the terminated cut one step too late
- Fixed issue, where truncations are not correctly applied to GAE buffer.